### PR TITLE
Add option for no prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ across apps, namespaces, etc.
 secret = Sekreto.get_json_value('MY-SECRET-CONFIG', 'shared-secrets')
 puts secret
 # Output: { some: 'json', data: 'here' }
+
+# Pass false for no prefix. Will query for "MY-SECRET-CONFIG"
+secret = Sekreto.get_json_value('MY-SECRET-CONFIG', false)
+puts secret
+# Output: { some: 'json', data: 'here' }
 ```
 
 ## Development

--- a/lib/sekreto.rb
+++ b/lib/sekreto.rb
@@ -64,9 +64,16 @@ module Sekreto
 
     private
 
-    def secret_name(secret_id, prefix = nil)
-      prefix ||= config.prefix
-      [prefix, secret_id].join('/')
+    def secret_name(secret_id, given_prefix = nil)
+      if given_prefix
+        prefix = given_prefix
+      elsif given_prefix == false
+        prefix = nil
+      else
+        prefix = config.prefix
+      end
+
+      [prefix, secret_id].compact.join('/')
     end
 
     def secrets_manager

--- a/lib/sekreto.rb
+++ b/lib/sekreto.rb
@@ -65,6 +65,7 @@ module Sekreto
     private
 
     def secret_name(secret_id, given_prefix = nil)
+      # rubocop:disable Style/ConditionalAssignment
       if given_prefix
         prefix = given_prefix
       elsif given_prefix == false
@@ -72,6 +73,7 @@ module Sekreto
       else
         prefix = config.prefix
       end
+      # rubocop:enable Style/ConditionalAssignment
 
       [prefix, secret_id].compact.join('/')
     end

--- a/spec/sekreto_spec.rb
+++ b/spec/sekreto_spec.rb
@@ -104,6 +104,20 @@ RSpec.describe Sekreto do
         expect(manager).to have_received(:get_secret_value).with(secret_id: prefixed_secret_id)
       end
     end
+
+    context 'when the prefix is false' do
+      let(:allowed_env) { true }
+
+      before do
+        allow(described_class).to receive(:secrets_manager) { manager }
+        allow(manager).to receive(:get_secret_value) { secret_response }
+        sekreto.get_value(secret_id, false)
+      end
+
+      it 'passes secret_id without a prefix' do
+        expect(manager).to have_received(:get_secret_value).with(secret_id: secret_id)
+      end
+    end
   end
 
   describe 'get_json_value' do


### PR DESCRIPTION
What
Some secrets, for better or worse, don't have a prefix. For example, not all apps use consistent environment naming conventions, so a 1-1 mapping may not be possible (hopefully not often).

Changes
Add an option so when you pass `false` as the prefix parameter, no prefix is attached. Does not break existing fallback behavior when `prefix` param is nil.