### PR TITLE
feat: Allow no prefix on lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,16 @@ puts secret
 # Output: { some: 'json', data: 'here' }
 ```
 
+If you want to skip prefixes all together you can pas `false` to either
+get value methods. **Not recommended**
+
+```ruby
+# Will query for "shared-secrets/MY-SECRET-CONFIG"
+secret = Sekreto.get_json_value('MY-SECRET-CONFIG', false)
+puts secret
+# Output: { some: 'json', data: 'here' }
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/sekreto.rb
+++ b/lib/sekreto.rb
@@ -65,8 +65,7 @@ module Sekreto
     private
 
     def secret_name(secret_id, prefix = nil)
-      prefix ||= config.prefix
-      [prefix, secret_id].join('/')
+      [config.prefix_name(prefix), secret_id].compact.join('/')
     end
 
     def secrets_manager

--- a/lib/sekreto/config.rb
+++ b/lib/sekreto/config.rb
@@ -4,6 +4,8 @@ module Sekreto
   ##
   # Config class for setting up Sekreto for usage
   class Config
+    DEFAULT_PREFIX = 'secrets'.freeze
+
     attr_accessor :prefix
     attr_accessor :is_allowed_env
     attr_accessor :fallback_lookup
@@ -16,11 +18,26 @@ module Sekreto
     #
     # @return [Sekreto::Config]
     def initialize
-      @prefix = 'secrets'
+      @prefix = DEFAULT_PREFIX
       @is_allowed_env = -> { true }
       @fallback_lookup = ->(secret_id) { ENV[secret_id] }
       @secrets_manager = nil
       @logger = Logger.new(STDOUT)
+    end
+
+    ##
+    #
+    # Get the prefix name to use when looking up secrets
+    #
+    # @param prefix_path [String,NilClass,FalseClass] - The path to use for the prefix
+    #
+    # @return [String] prefix path
+    #
+    # @example If a nil is passed it defaults to the config.prefix.
+    #          When a false is passed then no prefix is used. (Not recommended)
+    def prefix_name(prefix_path = nil)
+      return nil if prefix_path == false
+      prefix_path || prefix
     end
   end
 end

--- a/spec/sekreto/config_spec.rb
+++ b/spec/sekreto/config_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe Sekreto::Config do
-  describe 'initialize' do
-    subject(:config) { described_class.new }
+  subject(:config) { described_class.new }
 
+  describe 'initialize' do
     it 'defaults prefix' do
-      expect(config.prefix).to eq('secrets')
+      expect(config.prefix).to eq(described_class::DEFAULT_PREFIX)
     end
 
     it 'defaults allowed env to true' do
@@ -22,6 +22,34 @@ RSpec.describe Sekreto::Config do
 
       it 'defaults to check ENV' do
         expect(config.fallback_lookup.call(secret_id)).to eq(secret_val)
+      end
+    end
+  end
+
+  describe 'prefix_name' do
+    let(:prefix_name) { config.prefix_name(path) }
+
+    context 'when false path' do
+      let(:path) { false }
+
+      it 'returns nil' do
+        expect(prefix_name).to be_nil
+      end
+    end
+
+    context 'when nil path' do
+      let(:path) { nil }
+
+      it 'returns config prefix' do
+        expect(prefix_name).to eq(described_class::DEFAULT_PREFIX)
+      end
+    end
+
+    context 'when path passed in' do
+      let(:path) { 'la-la-la' }
+
+      it 'returns config prefix' do
+        expect(prefix_name).to eq(path)
       end
     end
   end

--- a/spec/sekreto_spec.rb
+++ b/spec/sekreto_spec.rb
@@ -104,6 +104,21 @@ RSpec.describe Sekreto do
         expect(manager).to have_received(:get_secret_value).with(secret_id: prefixed_secret_id)
       end
     end
+
+    context 'when prefix is false' do
+      let(:allowed_env) { true }
+      let(:prefixed_secret_id) { secret_id }
+
+      before do
+        allow(described_class).to receive(:secrets_manager) { manager }
+        allow(manager).to receive(:get_secret_value) { secret_response }
+        sekreto.get_value(secret_id, false)
+      end
+
+      it 'uses only secret_id for lookup' do
+        expect(manager).to have_received(:get_secret_value).with(secret_id: prefixed_secret_id)
+      end
+    end
   end
 
   describe 'get_json_value' do
@@ -138,6 +153,21 @@ RSpec.describe Sekreto do
       end
 
       it 'passes secret_id with overridden prefix' do
+        expect(manager).to have_received(:get_secret_value).with(secret_id: prefixed_secret_id)
+      end
+    end
+
+    context 'when prefix is false' do
+      let(:allowed_env) { true }
+      let(:prefixed_secret_id) { secret_id }
+
+      before do
+        allow(described_class).to receive(:secrets_manager) { manager }
+        allow(manager).to receive(:get_secret_value) { secret_response }
+        sekreto.get_json_value(secret_id, false)
+      end
+
+      it 'uses only secret_id for lookup' do
         expect(manager).to have_received(:get_secret_value).with(secret_id: prefixed_secret_id)
       end
     end


### PR DESCRIPTION
## What

Allow no prefix to be used. Not recommended but allowed.

## Changes

- Create a prefix_name method to check for no prefix
- Update specs for no prefix
- Update README

closes #14