### PR TITLE
Move railtie to before_configuration

### DIFF
--- a/lib/sekreto/railtie.rb
+++ b/lib/sekreto/railtie.rb
@@ -5,7 +5,7 @@ module Sekreto
   # Defaults the prefix to Rails app name and Rails.env e.g. foo-staging
   # Defaults allowed envs to check Rails.env is production or staging
   class Railtie < ::Rails::Railtie
-    config.before_initialize do
+    config.before_configuration do
       app_name = ::Rails.application.class.to_s.split('::').first.downcase
 
       Sekreto.setup do |setup|


### PR DESCRIPTION
Using `before_configuration` means that Sekreto can be used in config files, for example config/database.yml like so:

```
production:
  url: <%= Sekreto.get_value('DATABASE_URL') %>
```